### PR TITLE
Fix empty policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,16 @@
 locals {
+  source_documents = ["${concat(list("null", var.source_documents))}"]
   policies = [
-    "${length(var.source_documents) > 0 ? element(var.source_documents, 0) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 1 ? element(var.source_documents, 1) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 2 ? element(var.source_documents, 2) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 3 ? element(var.source_documents, 3) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 4 ? element(var.source_documents, 4) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 5 ? element(var.source_documents, 5) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 6 ? element(var.source_documents, 6) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 7 ? element(var.source_documents, 7) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 8 ? element(var.source_documents, 8) : data.aws_iam_policy_document.empty.json}",
-    "${length(var.source_documents) > 9 ? element(var.source_documents, 9) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 1 ? element(local.source_documents, 1) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 2 ? element(local.source_documents, 2) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 3 ? element(local.source_documents, 3) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 4 ? element(local.source_documents, 4) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 5 ? element(local.source_documents, 5) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 6 ? element(local.source_documents, 6) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 7 ? element(local.source_documents, 7) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 8 ? element(local.source_documents, 8) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 9 ? element(local.source_documents, 9) : data.aws_iam_policy_document.empty.json}",
+    "${length(local.source_documents) > 10 ? element(local.source_documents, 10) : data.aws_iam_policy_document.empty.json}",
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 locals {
+  ## Workaround to solve this problem https://github.com/hashicorp/terraform/issues/11210
   source_documents = ["${concat(list("null"), var.source_documents)}"]
 
   policies = [

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   source_documents = ["${concat(list("null"), var.source_documents)}"]
+
   policies = [
     "${length(local.source_documents) > 1 ? element(local.source_documents, 1) : data.aws_iam_policy_document.empty.json}",
     "${length(local.source_documents) > 2 ? element(local.source_documents, 2) : data.aws_iam_policy_document.empty.json}",

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  source_documents = ["${concat(list("null", var.source_documents))}"]
+  source_documents = ["${concat(list("null"), var.source_documents)}"]
   policies = [
     "${length(local.source_documents) > 1 ? element(local.source_documents, 1) : data.aws_iam_policy_document.empty.json}",
     "${length(local.source_documents) > 2 ? element(local.source_documents, 2) : data.aws_iam_policy_document.empty.json}",


### PR DESCRIPTION
## What
* Fix error `element: element() may not be used with an empty list` when `source_documents` are empty

## Why
* Allow creating roles with empty `policy`

https://github.com/hashicorp/terraform/issues/11210