### PR TITLE
Fix syntax error [GHI-8]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,84 +1,75 @@
 locals {
   ## Workaround to solve this problem https://github.com/hashicorp/terraform/issues/11210
-  source_documents = ["${concat(list("null"), var.source_documents)}"]
+  source_documents = [concat(["null"], var.source_documents)]
 
   policies = [
-    "${length(local.source_documents) > 1 ? element(local.source_documents, 1) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 2 ? element(local.source_documents, 2) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 3 ? element(local.source_documents, 3) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 4 ? element(local.source_documents, 4) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 5 ? element(local.source_documents, 5) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 6 ? element(local.source_documents, 6) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 7 ? element(local.source_documents, 7) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 8 ? element(local.source_documents, 8) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 9 ? element(local.source_documents, 9) : data.aws_iam_policy_document.empty.json}",
-    "${length(local.source_documents) > 10 ? element(local.source_documents, 10) : data.aws_iam_policy_document.empty.json}",
+    length(local.source_documents) > 1 ? element(local.source_documents, 1) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 2 ? element(local.source_documents, 2) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 3 ? element(local.source_documents, 3) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 4 ? element(local.source_documents, 4) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 5 ? element(local.source_documents, 5) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 6 ? element(local.source_documents, 6) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 7 ? element(local.source_documents, 7) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 8 ? element(local.source_documents, 8) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 9 ? element(local.source_documents, 9) : data.aws_iam_policy_document.empty.json,
+    length(local.source_documents) > 10 ? element(local.source_documents, 10) : data.aws_iam_policy_document.empty.json,
   ]
 }
 
-data "aws_iam_policy_document" "empty" {}
+data "aws_iam_policy_document" "empty" {
+}
 
 data "aws_iam_policy_document" "zero" {
-  source_json   = "${data.aws_iam_policy_document.empty.json}"
-  override_json = "${element(local.policies, 0)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.empty.json
+  override_json = element(local.policies, 0)
 }
 
 data "aws_iam_policy_document" "one" {
-  source_json   = "${data.aws_iam_policy_document.zero.json}"
-  override_json = "${element(local.policies, 1)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.zero.json
+  override_json = element(local.policies, 1)
 }
 
 data "aws_iam_policy_document" "two" {
-  source_json   = "${data.aws_iam_policy_document.one.json}"
-  override_json = "${element(local.policies, 2)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.one.json
+  override_json = element(local.policies, 2)
 }
 
 data "aws_iam_policy_document" "three" {
-  source_json   = "${data.aws_iam_policy_document.two.json}"
-  override_json = "${element(local.policies, 3)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.two.json
+  override_json = element(local.policies, 3)
 }
 
 data "aws_iam_policy_document" "four" {
-  source_json   = "${data.aws_iam_policy_document.three.json}"
-  override_json = "${element(local.policies, 4)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.three.json
+  override_json = element(local.policies, 4)
 }
 
 data "aws_iam_policy_document" "five" {
-  source_json   = "${data.aws_iam_policy_document.four.json}"
-  override_json = "${element(local.policies, 5)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.four.json
+  override_json = element(local.policies, 5)
 }
 
 data "aws_iam_policy_document" "six" {
-  source_json   = "${data.aws_iam_policy_document.five.json}"
-  override_json = "${element(local.policies, 6)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.five.json
+  override_json = element(local.policies, 6)
 }
 
 data "aws_iam_policy_document" "seven" {
-  source_json   = "${data.aws_iam_policy_document.six.json}"
-  override_json = "${element(local.policies, 7)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.six.json
+  override_json = element(local.policies, 7)
 }
 
 data "aws_iam_policy_document" "eight" {
-  source_json   = "${data.aws_iam_policy_document.seven.json}"
-  override_json = "${element(local.policies, 8)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.seven.json
+  override_json = element(local.policies, 8)
 }
 
 data "aws_iam_policy_document" "nine" {
-  source_json   = "${data.aws_iam_policy_document.eight.json}"
-  override_json = "${element(local.policies, 9)}"
-  "statement"   = []
+  source_json   = data.aws_iam_policy_document.eight.json
+  override_json = element(local.policies, 9)
 }
 
 data "aws_iam_policy_document" "default" {
-  source_json = "${data.aws_iam_policy_document.nine.json}"
-  "statement" = []
+  source_json = data.aws_iam_policy_document.nine.json
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,4 +1,5 @@
 output "result_document" {
-  value       = "${data.aws_iam_policy_document.default.json}"
+  value       = data.aws_iam_policy_document.default.json
   description = "Aggregeted IAM policy"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,6 @@
 variable "source_documents" {
-  type        = "list"
+  type        = list(string)
   description = "List of JSON IAM policy documents.<br/><br/><b>Limits:</b><br/>* List size max 10<br/> * Statement can be overriden by the statement with the same sid from the latest policy."
   default     = []
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Fixes issue #8 by upgrading the module to `0.12+`

[GHI-8]: https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator/issues/8