### PR TITLE
patch/source_policy_documents

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,10 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/context.tf   @cloudposse/engineering @cloudposse/approvers
-README.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-docs/*.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 
 # Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
 .github/mergify.yml @cloudposse/admins

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:
@@ -46,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -56,3 +56,10 @@ pull_request_rules:
       changes_requested: true
       approved: true
       message: "This Pull Request has been updated, so we're dismissing all reviews."
+
+- name: "close Pull Requests without files changed"
+  conditions:
+    - "#files=0"
+  actions:
+    close:
+      message: "This pull request has been automatically closed by Mergify because there are no longer any changes."

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.update.outputs.create_pull_request == 'true'
-      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-format:
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:slim-latest
+    container: cloudposse/build-harness:latest
     steps:
     # Checkout the pull request branch
     #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
@@ -29,6 +29,8 @@ jobs:
     - name: Auto Format
       if: github.event.pull_request.state == 'open'
       shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch
@@ -60,7 +62,7 @@ jobs:
         fi
 
     - name: Auto Test
-      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      uses: cloudposse/actions/github/repository-dispatch@0.30.0
       # match users by ID because logins (user names) are inconsistent,
       # for example in the REST API Renovate Bot is `renovate[bot]` but
       # in GraphQL it is just `renovate`, plus there is a non-bot

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,71 @@
+name: "auto-readme"
+on:
+  workflow_dispatch:
+
+  schedule:
+  # Example of job definition:
+  # .---------------- minute (0 - 59)
+  # |  .------------- hour (0 - 23)
+  # |  |  .---------- day of month (1 - 31)
+  # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+  # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+  # |  |  |  |  |
+  # *  *  *  *  * user-name command to be executed
+
+  # Update README.md nightly at 4am UTC
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
+      run: |
+        make init
+        make readme/build
+        # Ignore changes if they are only whitespace
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
+
+    - name: Create Pull Request
+      # This action will not create or change a pull request if there are no changes to make.
+      # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
+        delete-branch: true
+        labels: |
+          auto-update
+          no-release
+          readme

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,24 @@ name: auto-release
 on:
   push:
     branches:
-    - master
+      - main
+      - master
+      - production
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: true
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Get PR from merged commit to master
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          prerelease: false
+          config-name: auto-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 name: Validate Codeowners
 on:
+  workflow_dispatch:
+
   pull_request:
 
 jobs:
@@ -8,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -16,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-iam-policy-document-aggregator
 
@@ -31,7 +32,6 @@
 
 Terraform module to aggregate multiple IAM policy documents into single policy document.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -56,7 +56,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 
@@ -160,27 +159,47 @@ The [`example`](./example) directory contains the example.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 2.23 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.23 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.23 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eight](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.five](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.four](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.nine](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.seven](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.six](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.three](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.two](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.zero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| source\_documents | List of JSON IAM policy documents.<br/><br/><b>Limits:</b><br/>\* List size max 10<br/> \* Statement can be overriden by the statement with the same sid from the latest policy. | `list(string)` | `[]` | no |
+| <a name="input_source_documents"></a> [source\_documents](#input\_source\_documents) | List of JSON IAM policy documents.<br/><br/><b>Limits:</b><br/>* List size max 10<br/> * Statement can be overriden by the statement with the same sid from the latest policy. | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| result\_document | Aggregated IAM policy |
-
+| <a name="output_result_document"></a> [result\_document](#output\_result\_document) | Aggregated IAM policy |
 <!-- markdownlint-restore -->
 
 
@@ -192,14 +211,13 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [terraform-aws-iam-role](https://github.com/cloudposse/terraform-aws-iam-role) - A Terraform module that creates IAM role with provided JSON IAM polices documents.
 - [terraform-aws-iam-chamber-s3-role](https://github.com/cloudposse/terraform-aws-iam-chamber-s3-role) - Terraform module to provision an IAM role with configurable permissions to access S3 as chamber backend.
-
-
 
 ## Help
 
@@ -272,7 +290,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,25 +3,45 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 2.23 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.23 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.23 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eight](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.empty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.five](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.four](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.nine](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.seven](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.six](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.three](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.two](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.zero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| source\_documents | List of JSON IAM policy documents.<br/><br/><b>Limits:</b><br/>\* List size max 10<br/> \* Statement can be overriden by the statement with the same sid from the latest policy. | `list(string)` | `[]` | no |
+| <a name="input_source_documents"></a> [source\_documents](#input\_source\_documents) | List of JSON IAM policy documents.<br/><br/><b>Limits:</b><br/>* List size max 10<br/> * Statement can be overriden by the statement with the same sid from the latest policy. | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| result\_document | Aggregated IAM policy |
-
+| <a name="output_result_document"></a> [result\_document](#output\_result\_document) | Aggregated IAM policy |
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -19,53 +19,53 @@ locals {
 data "aws_iam_policy_document" "empty" {}
 
 data "aws_iam_policy_document" "zero" {
-  source_policy_documents = [data.aws_iam_policy_document.empty.json]
-  override_json           = element(local.policies, 0)
+  source_policy_documents   = [data.aws_iam_policy_document.empty.json]
+  override_policy_documents = [element(local.policies, 0)]
 }
 
 data "aws_iam_policy_document" "one" {
-  source_policy_documents = [data.aws_iam_policy_document.zero.json]
-  override_json           = element(local.policies, 1)
+  source_policy_documents   = [data.aws_iam_policy_document.zero.json]
+  override_policy_documents = [element(local.policies, 1)]
 }
 
 data "aws_iam_policy_document" "two" {
-  source_policy_documents = [data.aws_iam_policy_document.one.json]
-  override_json           = element(local.policies, 2)
+  source_policy_documents   = [data.aws_iam_policy_document.one.json]
+  override_policy_documents = [element(local.policies, 2)]
 }
 
 data "aws_iam_policy_document" "three" {
-  source_policy_documents = [data.aws_iam_policy_document.two.json]
-  override_json           = element(local.policies, 3)
+  source_policy_documents   = [data.aws_iam_policy_document.two.json]
+  override_policy_documents = [element(local.policies, 3)]
 }
 
 data "aws_iam_policy_document" "four" {
-  source_policy_documents = [data.aws_iam_policy_document.three.json]
-  override_json           = element(local.policies, 4)
+  source_policy_documents   = [data.aws_iam_policy_document.three.json]
+  override_policy_documents = [element(local.policies, 4)]
 }
 
 data "aws_iam_policy_document" "five" {
-  source_policy_documents = [data.aws_iam_policy_document.four.json]
-  override_json           = element(local.policies, 5)
+  source_policy_documents   = [data.aws_iam_policy_document.four.json]
+  override_policy_documents = [element(local.policies, 5)]
 }
 
 data "aws_iam_policy_document" "six" {
-  source_policy_documents = [data.aws_iam_policy_document.five.json]
-  override_json           = element(local.policies, 6)
+  source_policy_documents   = [data.aws_iam_policy_document.five.json]
+  override_policy_documents = [element(local.policies, 6)]
 }
 
 data "aws_iam_policy_document" "seven" {
-  source_policy_documents = [data.aws_iam_policy_document.six.json]
-  override_json           = element(local.policies, 7)
+  source_policy_documents   = [data.aws_iam_policy_document.six.json]
+  override_policy_documents = [element(local.policies, 7)]
 }
 
 data "aws_iam_policy_document" "eight" {
-  source_policy_documents = [data.aws_iam_policy_document.seven.json]
-  override_json           = element(local.policies, 8)
+  source_policy_documents   = [data.aws_iam_policy_document.seven.json]
+  override_policy_documents = [element(local.policies, 8)]
 }
 
 data "aws_iam_policy_document" "nine" {
-  source_policy_documents = [data.aws_iam_policy_document.eight.json]
-  override_json           = element(local.policies, 9)
+  source_policy_documents   = [data.aws_iam_policy_document.eight.json]
+  override_policy_documents = [element(local.policies, 9)]
 }
 
 data "aws_iam_policy_document" "default" {

--- a/main.tf
+++ b/main.tf
@@ -16,59 +16,58 @@ locals {
   ]
 }
 
-data "aws_iam_policy_document" "empty" {
-}
+data "aws_iam_policy_document" "empty" {}
 
 data "aws_iam_policy_document" "zero" {
-  source_json   = data.aws_iam_policy_document.empty.json
-  override_json = element(local.policies, 0)
+  source_policy_documents = [data.aws_iam_policy_document.empty.json]
+  override_json           = element(local.policies, 0)
 }
 
 data "aws_iam_policy_document" "one" {
-  source_json   = data.aws_iam_policy_document.zero.json
-  override_json = element(local.policies, 1)
+  source_policy_documents = [data.aws_iam_policy_document.zero.json]
+  override_json           = element(local.policies, 1)
 }
 
 data "aws_iam_policy_document" "two" {
-  source_json   = data.aws_iam_policy_document.one.json
-  override_json = element(local.policies, 2)
+  source_policy_documents = [data.aws_iam_policy_document.one.json]
+  override_json           = element(local.policies, 2)
 }
 
 data "aws_iam_policy_document" "three" {
-  source_json   = data.aws_iam_policy_document.two.json
-  override_json = element(local.policies, 3)
+  source_policy_documents = [data.aws_iam_policy_document.two.json]
+  override_json           = element(local.policies, 3)
 }
 
 data "aws_iam_policy_document" "four" {
-  source_json   = data.aws_iam_policy_document.three.json
-  override_json = element(local.policies, 4)
+  source_policy_documents = [data.aws_iam_policy_document.three.json]
+  override_json           = element(local.policies, 4)
 }
 
 data "aws_iam_policy_document" "five" {
-  source_json   = data.aws_iam_policy_document.four.json
-  override_json = element(local.policies, 5)
+  source_policy_documents = [data.aws_iam_policy_document.four.json]
+  override_json           = element(local.policies, 5)
 }
 
 data "aws_iam_policy_document" "six" {
-  source_json   = data.aws_iam_policy_document.five.json
-  override_json = element(local.policies, 6)
+  source_policy_documents = [data.aws_iam_policy_document.five.json]
+  override_json           = element(local.policies, 6)
 }
 
 data "aws_iam_policy_document" "seven" {
-  source_json   = data.aws_iam_policy_document.six.json
-  override_json = element(local.policies, 7)
+  source_policy_documents = [data.aws_iam_policy_document.six.json]
+  override_json           = element(local.policies, 7)
 }
 
 data "aws_iam_policy_document" "eight" {
-  source_json   = data.aws_iam_policy_document.seven.json
-  override_json = element(local.policies, 8)
+  source_policy_documents = [data.aws_iam_policy_document.seven.json]
+  override_json           = element(local.policies, 8)
 }
 
 data "aws_iam_policy_document" "nine" {
-  source_json   = data.aws_iam_policy_document.eight.json
-  override_json = element(local.policies, 9)
+  source_policy_documents = [data.aws_iam_policy_document.eight.json]
+  override_json           = element(local.policies, 9)
 }
 
 data "aws_iam_policy_document" "default" {
-  source_json = data.aws_iam_policy_document.nine.json
+  source_policy_documents = [data.aws_iam_policy_document.nine.json]
 }


### PR DESCRIPTION
## what
* revises 'source_json' to 'source_policy_documents'. All references are adjusted to list notation as expected by terraform.
* revises 'override_json' to 'override_policy_documents'. All references are adjusted to list notation as expected by terraform.
* This change addresses the warning 'Warning: Argument is deprecated, Use the attribute "source_policy_documents" instead' warning, along with `Warning: Argument is deprecated, Use the attribute "override_policy_documents" instead.'

## why
* The proposed changes satiate what the AWS provider expects on more recent versions and will clear related warning messages. 